### PR TITLE
Consolidate GitHub badge utilities

### DIFF
--- a/script.js
+++ b/script.js
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', function() {
         try {
             // Use shields.io badge for better reliability
             const badgeUrl = `https://img.shields.io/github/actions/workflow/status/${owner}/${repo}/${workflowFile}`;
-            const status = await parseBadgeSVG(badgeUrl)
+            const status = await GitHubUtils.parseBadgeSVG(badgeUrl)
             
             updateWorkflowStatusUI({
                 status: status,
@@ -46,97 +46,6 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // Parse SVG badge text to determine status
-    async function parseBadgeSVG(badgeUrl) {
-        try {
-            const response = await fetch(badgeUrl + `?t=${Date.now()}`);
-            
-            if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
-            }
-            
-            const svgText = await response.text();
-            console.log('Badge SVG content:', svgText);
-            
-            // Parse the SVG text for status words
-            const status = parseStatusFromSVG(svgText);
-            return status;
-            
-        } catch (error) {
-            console.error('Error fetching SVG badge:', error);
-            return 'unknown';
-        }
-    }
-
-    function parseStatusFromSVG(svgText) {
-        // Convert to lowercase for easier matching
-        const lowerText = svgText.toLowerCase();
-        
-        console.log('Searching for status words in SVG...');
-        
-        // Look for common status words
-        if (lowerText.includes('passing') || lowerText.includes('success')) {
-            console.log('✅ Found "passing" or "success" in SVG');
-            return 'success';
-        }
-        
-        if (lowerText.includes('failing') || lowerText.includes('failure') || lowerText.includes('failed')) {
-            console.log('❌ Found "failing" or "failure" in SVG');
-            return 'failure';
-        }
-        
-        if (lowerText.includes('pending') || lowerText.includes('running') || lowerText.includes('in progress')) {
-            console.log('🔄 Found "pending" or "running" in SVG');
-            return 'in_progress';
-        }
-        
-        if (lowerText.includes('no status') || lowerText.includes('unknown')) {
-            console.log('❔ Found "no status" or "unknown" in SVG');
-            return 'unknown';
-        }
-        
-        // If we can't find specific status words, log what we found
-        console.log('⚠️ No recognized status words found. SVG might contain:', 
-                   svgText.match(/>([^<]+)</g)?.map(match => match.slice(1, -1)).filter(text => text.trim()));
-        
-        return 'unknown';
-    }
-
-    function getTimeAgo(date) {
-        const now = new Date();
-        const diffInSeconds = Math.floor((now - date) / 1000);
-        
-        if (diffInSeconds < 60) return `<1m ago`;
-        if (diffInSeconds < 3600) return `${Math.floor(diffInSeconds / 60)}m ago`;
-        if (diffInSeconds < 86400) return `${Math.floor(diffInSeconds / 3600)}h ago`;
-        return `${Math.floor(diffInSeconds / 86400)}d ago`;
-    }
-
-
-
-    function parseShieldsStatus(statusValue) {
-        if (!statusValue) return 'unknown';
-        
-        const status = statusValue.toLowerCase();
-        console.log('Status value from shields.io:', status);
-        
-        // Map shields.io status values to our status system
-        if (status.includes('passing') || status.includes('success')) {
-            return 'success';
-        }
-        if (status.includes('failing') || status.includes('failure') || status.includes('error')) {
-            return 'failure';
-        }
-        if (status.includes('pending') || status.includes('running') || status.includes('in progress')) {
-            return 'in_progress';
-        }
-        if (status.includes('no status') || status.includes('unknown')) {
-            return 'unknown';
-        }
-        
-        // Default case
-        return 'unknown';
-    }
 
     function updateWorkflowStatusUI(workflowData, skipTimeUpdate = false) {
         const statusElement = document.querySelector('[data-frontend-status]');
@@ -163,7 +72,7 @@ document.addEventListener('DOMContentLoaded', function() {
         
         // Only update timestamp if not skipping
         if (!skipTimeUpdate) {
-            const timeAgo = getTimeAgo(workflowData.updatedAt);
+            const timeAgo = GitHubUtils.getTimeAgo(workflowData.updatedAt);
             timeElement.innerHTML = `
                 <div class="flex items-center space-x-2">
                     <i class="fas fa-sync text-gray-400 text-xs"></i>
@@ -353,7 +262,7 @@ document.addEventListener('DOMContentLoaded', function() {
     function updateTimestamp() {
         const timeElement = document.querySelector('[data-frontend-time] span');
         if (timeElement) {
-            const timeSinceUpdate = getTimeAgo(lastStatusUpdate);
+            const timeSinceUpdate = GitHubUtils.getTimeAgo(lastStatusUpdate);
             timeElement.textContent = `Updated ${timeSinceUpdate}`;
         }
     }
@@ -660,13 +569,3 @@ document.addEventListener('DOMContentLoaded', function() {
 
     console.log('Kanban Board initialized successfully!');
 });
-
-// Export functions for testing (Node.js environment only)
-if (typeof module !== 'undefined' && module.exports) {
-    module.exports = {
-        parseStatusFromSVG,
-        getTimeAgo,
-        parseShieldsStatus,
-        updateWorkflowStatusUI: typeof updateWorkflowStatusUI !== 'undefined' ? updateWorkflowStatusUI : null
-    };
-} 


### PR DESCRIPTION
## Summary
- use shared GitHubUtils functions in `script.js`
- remove duplicate badge utility implementations
- drop unused Node.js export block

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844c636e1dc83208bd22dc48c93bd59