### PR TITLE
Add full coverage for kanban.js

### DIFF
--- a/src/kanban.js
+++ b/src/kanban.js
@@ -590,7 +590,19 @@ document.addEventListener('DOMContentLoaded', function() {
         addTaskBtn,
         addTaskModal,
         cancelTaskBtn,
-        addTaskForm
+        addTaskForm,
+        // expose internals for testing
+        loadCollapseStates,
+        saveCollapseStates,
+        loadGitHubIssues,
+        renderMarkdown,
+        createGitHubIssueElement,
+        extractPriorityFromLabels,
+        extractCategoryFromLabels,
+        getPriorityColor,
+        getCategoryColor,
+        createSkeletonCard,
+        initializeGitHubIssues
     };
 
     // Attach to global for browser/Node access


### PR DESCRIPTION
## Summary
- export internal helpers from `kanban.js` so tests can invoke them
- rework kanban tests to use exported helpers instead of dynamic evaluation
- reset DOM and module state before each test
- adjust expectations to avoid brittle counts

## Testing
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6845bc93bde48320956974e070eb3f9e