### PR TITLE
Improve export handling and tests

### DIFF
--- a/src/status-cards.js
+++ b/src/status-cards.js
@@ -369,15 +369,26 @@ document.addEventListener('DOMContentLoaded', function() {
         refreshAllStatuses,
         parseCoverageFromSVG,
         updateTimestamp,
-        setupBadgeDebugging
+        setupBadgeDebugging,
+        attachExports
     };
 
-    // Attach to global for browser/Node access
-    if (typeof globalThis !== 'undefined') {
-        globalThis.statusCardsTestExports = statusAPI;
+    function attachExports(globalObj, moduleObj) {
+        const g = typeof globalObj !== 'undefined' ? globalObj : (typeof globalThis !== 'undefined' ? globalThis : undefined);
+        let m = typeof moduleObj !== 'undefined' ? moduleObj : undefined;
+        if (typeof m === 'undefined' && typeof module !== 'undefined') {
+            m = module;
+        }
+
+        if (typeof g !== 'undefined') {
+            g.statusCardsTestExports = statusAPI;
+        }
+
+        if (typeof m !== 'undefined' && m.exports) {
+            m.exports = statusAPI;
+        }
     }
 
-    if (typeof module !== 'undefined' && module.exports) {
-        module.exports = statusAPI;
-    }
+    // Attach to global for browser/Node access using actual environment
+    attachExports();
 }); 

--- a/tests/status-cards.test.js
+++ b/tests/status-cards.test.js
@@ -914,5 +914,31 @@ describe('Status Cards Functions', () => {
       vm.runInContext(code, sandbox);
       expect(mockModule.exports).toBeUndefined(); // should not have exports
     });
+
+    test('attachExports handles undefined globals', () => {
+      expect(() => {
+        statusAPI.attachExports(undefined, undefined);
+      }).not.toThrow();
+    });
+
+    test('attachExports attaches to provided objects', () => {
+      const customGlobal = {};
+      const customModule = { exports: {} };
+      statusAPI.attachExports(customGlobal, customModule);
+      expect(customGlobal.statusCardsTestExports).toBeDefined();
+      expect(customModule.exports.fetchWorkflowStatus).toBeDefined();
+    });
+
+    test('attachExports falls back to current module when moduleObj missing', () => {
+      const customGlobal = {};
+      statusAPI.attachExports(customGlobal, undefined);
+      expect(customGlobal.statusCardsTestExports).toBeDefined();
+    });
+
+    test('attachExports falls back to globalThis when globalObj missing', () => {
+      const customModule = { exports: {} };
+      statusAPI.attachExports(undefined, customModule);
+      expect(customModule.exports.fetchWorkflowStatus).toBeDefined();
+    });
   });
-}); 
+});


### PR DESCRIPTION
## Summary
- enhance export logic in `status-cards.js`
- expand tests for `attachExports`

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_6845bcc229a48320a4234852adac25e4