### PR TITLE
Introduce silent mode in Logger

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
     <!-- Markdown parsing and sanitization -->
     <script src="https://cdn.jsdelivr.net/npm/markdown-it@14.0.0/dist/markdown-it.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"></script>
+    <!-- Global logging utility -->
+    <script src="src/logger.js"></script>
     <script src="src/utils.js"></script>
     <style>
         .sortable-ghost {

--- a/src/github-api.js
+++ b/src/github-api.js
@@ -8,7 +8,7 @@ function isTestEnvironment() {
 // Archive GitHub issue by adding "archive" label
 async function archiveGitHubIssue(issueNumber, taskElement) {
     if (!window.GitHubAuth.githubAuth.isAuthenticated || !window.GitHubAuth.githubAuth.accessToken) {
-        console.log('❌ Not authenticated with GitHub App - cannot archive issue');
+        Logger.info('❌ Not authenticated with GitHub App - cannot archive issue');
         // Remove from UI anyway
         taskElement.remove();
         window.updateColumnCounts();
@@ -16,7 +16,7 @@ async function archiveGitHubIssue(issueNumber, taskElement) {
     }
 
     try {
-        console.log(`🗃️ Archiving issue #${issueNumber}...`);
+        Logger.info(`🗃️ Archiving issue #${issueNumber}...`);
 
         // Add "archive" label to the issue
         const response = await fetch(`${window.GitHubAuth.GITHUB_CONFIG.apiBaseUrl}/repos/${window.GitHubAuth.GITHUB_CONFIG.owner}/${window.GitHubAuth.GITHUB_CONFIG.repo}/issues/${issueNumber}/labels`, {
@@ -36,14 +36,14 @@ async function archiveGitHubIssue(issueNumber, taskElement) {
             throw new Error(`GitHub API error: ${response.status} - ${errorData.message || 'Unknown error'}`);
         }
 
-        console.log(`✅ Successfully archived issue #${issueNumber}`);
+        Logger.info(`✅ Successfully archived issue #${issueNumber}`);
         
         // Remove from UI
         taskElement.remove();
         window.updateColumnCounts();
         
     } catch (error) {
-        console.error('❌ Failed to archive GitHub issue:', error);
+        Logger.error('❌ Failed to archive GitHub issue:', error);
         
         // Show user-friendly error message but still remove from UI
         alert(`Failed to add archive label to GitHub issue: ${error.message}\n\nThe task will be removed from the board anyway.`);
@@ -55,12 +55,12 @@ async function archiveGitHubIssue(issueNumber, taskElement) {
 // Update GitHub issue labels when moved between columns
 async function updateGitHubIssueLabels(issueNumber, newColumn) {
     if (!window.GitHubAuth.githubAuth.isAuthenticated || !window.GitHubAuth.githubAuth.accessToken) {
-        console.log('❌ Not authenticated with GitHub App - cannot update issue labels');
+        Logger.info('❌ Not authenticated with GitHub App - cannot update issue labels');
         return;
     }
 
     try {
-        console.log(`🔄 Updating labels for issue #${issueNumber} moved to ${newColumn}...`);
+        Logger.info(`🔄 Updating labels for issue #${issueNumber} moved to ${newColumn}...`);
 
         // First, get current issue to preserve existing labels
         const getResponse = await fetch(`${window.GitHubAuth.GITHUB_CONFIG.apiBaseUrl}/repos/${window.GitHubAuth.GITHUB_CONFIG.owner}/${window.GitHubAuth.GITHUB_CONFIG.repo}/issues/${issueNumber}?_t=${Date.now()}`, {
@@ -115,10 +115,10 @@ async function updateGitHubIssueLabels(issueNumber, newColumn) {
 
         const columnDisplayName = newColumn === 'inprogress' ? 'In Progress' : 
                                  newColumn.charAt(0).toUpperCase() + newColumn.slice(1);
-        console.log(`✅ Successfully updated labels for issue #${issueNumber} (moved to ${columnDisplayName})`);
+        Logger.info(`✅ Successfully updated labels for issue #${issueNumber} (moved to ${columnDisplayName})`);
         
     } catch (error) {
-        console.error('❌ Failed to update GitHub issue labels:', error);
+        Logger.error('❌ Failed to update GitHub issue labels:', error);
         
         // Show user-friendly error message but don't revert the UI change
         const columnDisplayName = newColumn === 'inprogress' ? 'In Progress' : 
@@ -130,12 +130,12 @@ async function updateGitHubIssueLabels(issueNumber, newColumn) {
 // Close GitHub issue when moved to Done column
 async function closeGitHubIssue(issueNumber) {
     if (!window.GitHubAuth.githubAuth.isAuthenticated || !window.GitHubAuth.githubAuth.accessToken) {
-        console.log('❌ Not authenticated with GitHub App - cannot close issue');
+        Logger.info('❌ Not authenticated with GitHub App - cannot close issue');
         return;
     }
 
     try {
-        console.log(`🔒 Closing GitHub issue #${issueNumber}...`);
+        Logger.info(`🔒 Closing GitHub issue #${issueNumber}...`);
 
         // Close the issue via API
         const response = await fetch(`${window.GitHubAuth.GITHUB_CONFIG.apiBaseUrl}/repos/${window.GitHubAuth.GITHUB_CONFIG.owner}/${window.GitHubAuth.GITHUB_CONFIG.repo}/issues/${issueNumber}`, {
@@ -155,10 +155,10 @@ async function closeGitHubIssue(issueNumber) {
             throw new Error(`GitHub API error: ${response.status} - ${errorData.message || 'Unknown error'}`);
         }
 
-        console.log(`✅ Successfully closed GitHub issue #${issueNumber}`);
+        Logger.info(`✅ Successfully closed GitHub issue #${issueNumber}`);
         
     } catch (error) {
-        console.error('❌ Failed to close GitHub issue:', error);
+        Logger.error('❌ Failed to close GitHub issue:', error);
         
         // Show user-friendly error message but don't revert the UI change
         alert(`Failed to close GitHub issue: ${error.message}\n\nThe issue was moved to Done on the board but wasn't closed on GitHub.`);
@@ -168,12 +168,12 @@ async function closeGitHubIssue(issueNumber) {
 // Create GitHub issue via API
 async function createGitHubIssue(title, description, labels = []) {
     if (!window.GitHubAuth.githubAuth.isAuthenticated || !window.GitHubAuth.githubAuth.accessToken) {
-        console.log('❌ Not authenticated with GitHub App - cannot create issue');
+        Logger.info('❌ Not authenticated with GitHub App - cannot create issue');
         return null;
     }
 
     try {
-        console.log('🔄 Creating GitHub issue...');
+        Logger.info('🔄 Creating GitHub issue...');
 
         const response = await fetch(`${window.GitHubAuth.GITHUB_CONFIG.apiBaseUrl}/repos/${window.GitHubAuth.GITHUB_CONFIG.owner}/${window.GitHubAuth.GITHUB_CONFIG.repo}/issues`, {
             method: 'POST',
@@ -195,13 +195,13 @@ async function createGitHubIssue(title, description, labels = []) {
         }
 
         const issue = await response.json();
-        console.log('✅ Successfully created GitHub issue:', issue.number);
+        Logger.info('✅ Successfully created GitHub issue:', issue.number);
         return issue;
 
     } catch (error) {
         // Only log errors in non-test environments
         if (!isTestEnvironment()) {
-            console.error('❌ Failed to create GitHub issue:', error);
+            Logger.error('❌ Failed to create GitHub issue:', error);
         }
         
         // Show user-friendly error message
@@ -217,7 +217,7 @@ async function createGitHubIssue(title, description, labels = []) {
 // GitHub Issues Integration
 async function loadGitHubIssues() {
     try {
-        console.log('Loading GitHub issues...');
+        Logger.info('Loading GitHub issues...');
         
         // Fetch both open and closed issues with cache-busting
         const timestamp = Date.now();
@@ -243,7 +243,7 @@ async function loadGitHubIssues() {
             !issue.labels.some(label => label.name.toLowerCase() === 'archive')
         );
         
-        console.log(`Found ${openIssues.length} open and ${closedIssues.length} closed GitHub issues (filtered out archived issues)`);
+        Logger.info(`Found ${openIssues.length} open and ${closedIssues.length} closed GitHub issues (filtered out archived issues)`);
         
         // Clear existing issue cards (but keep manually created tasks)
         const columns = ['backlog', 'inprogress', 'review', 'done'];
@@ -297,19 +297,19 @@ async function loadGitHubIssues() {
         // Apply completed sections to all cards in the done column
         window.GitHubUI.applyCompletedSectionsToColumn();
         
-        console.log('✅ GitHub issues loaded successfully');
+        Logger.info('✅ GitHub issues loaded successfully');
         
     } catch (error) {
         // Only log errors in non-test environments to avoid console noise during tests
         if (!isTestEnvironment()) {
-            console.error('❌ Failed to load GitHub issues:', error);
+            Logger.error('❌ Failed to load GitHub issues:', error);
         }
         // Don't show alert for loading issues - just log the error
     }
 }
 
 function initializeGitHubIssues() {
-    console.log('🔄 Initializing GitHub issues integration...');
+    Logger.info('🔄 Initializing GitHub issues integration...');
     
     // Add skeleton cards while loading
     const columns = ['backlog', 'inprogress', 'review', 'done'];

--- a/src/github-auth.js
+++ b/src/github-auth.js
@@ -72,7 +72,7 @@ function initializeGitHubAuth() {
             validateAndSetInstallation(savedInstallationId);
         } else if (savedToken) {
             // We have a token but no installation ID - try to validate token
-            console.log('🔄 Found saved token without installation ID, validating...');
+            Logger.info('🔄 Found saved token without installation ID, validating...');
             githubAuth.isAuthenticated = true; // Assume app is installed
             validateAndSetToken(savedToken);
             return; // Don't call updateGitHubSignInUI() yet, let validateAndSetToken() do it
@@ -94,18 +94,18 @@ function signInWithGitHub() {
 
 async function handleInstallationCallback(installationId, authCode = null) {
     try {
-        console.log('🔄 Processing GitHub App installation...');
+        Logger.info('🔄 Processing GitHub App installation...');
         
         // Store installation ID
         githubAuth.installationId = installationId;
         githubAuth.isAuthenticated = true;
         localStorage.setItem('github_installation_id', installationId);
         
-        console.log('✅ GitHub App installed successfully!');
+        Logger.info('✅ GitHub App installed successfully!');
         
         if (authCode) {
             // We have an OAuth authorization code
-            console.log('🔄 OAuth authorization code received');
+            Logger.info('🔄 OAuth authorization code received');
             
             // Show the GitHub token modal instead of browser prompt
             showGitHubTokenModal();
@@ -114,14 +114,14 @@ async function handleInstallationCallback(installationId, authCode = null) {
             updateGitHubSignInUI();
         }
     } catch (error) {
-        console.error('❌ Installation callback error:', error);
+        Logger.error('❌ Installation callback error:', error);
         alert('Installation failed. Please try again.');
     }
 }
 
 async function validateAndSetToken(token) {
     try {
-        console.log('🔄 Validating GitHub token...');
+        Logger.info('🔄 Validating GitHub token...');
         
         const response = await fetch(`${GITHUB_CONFIG.apiBaseUrl}/user`, {
             headers: {
@@ -143,14 +143,14 @@ async function validateAndSetToken(token) {
         
         localStorage.setItem('github_access_token', token);
         
-        console.log('✅ GitHub authentication successful:', user.login);
+        Logger.info('✅ GitHub authentication successful:', user.login);
         updateGitHubSignInUI();
         
         return true;
     } catch (error) {
         // Only log errors in non-test environments
         if (typeof jest === 'undefined') {
-            console.error('❌ Token validation failed:', error);
+            Logger.error('❌ Token validation failed:', error);
         }
         signOutGitHub();
         return false;
@@ -159,7 +159,7 @@ async function validateAndSetToken(token) {
 
 async function validateAndSetInstallation(installationId) {
     try {
-        console.log('🔄 Validating GitHub App installation...');
+        Logger.info('🔄 Validating GitHub App installation...');
         
         // Store installation
         githubAuth.installationId = installationId;
@@ -175,14 +175,14 @@ async function validateAndSetInstallation(installationId) {
         
         return true;
     } catch (error) {
-        console.error('❌ Installation validation failed:', error);
+        Logger.error('❌ Installation validation failed:', error);
         signOutGitHub();
         return false;
     }
 }
 
 function signOutGitHub() {
-    console.log('🔓 Signing out of GitHub App...');
+    Logger.info('🔓 Signing out of GitHub App...');
     
     // Check if app was installed before clearing state
     const hadInstallation = !!(githubAuth.installationId || localStorage.getItem('github_installation_id'));
@@ -194,7 +194,7 @@ function signOutGitHub() {
     if (hadInstallation) {
         // Keep installation state, just remove token
         githubAuth.isAuthenticated = true; // App still installed
-        console.log('🔄 Cleared access token but keeping app installation');
+        Logger.info('🔄 Cleared access token but keeping app installation');
     } else {
         // No installation, clear everything
         githubAuth.isAuthenticated = false;
@@ -207,15 +207,15 @@ function signOutGitHub() {
     // Update UI
     updateGitHubSignInUI();
     
-    console.log('✅ Successfully signed out and cleared access token');
+    Logger.info('✅ Successfully signed out and cleared access token');
     
     // Show appropriate reconnection message
     setTimeout(() => {
         if (window.location.href.includes('localhost') || window.location.href.includes('127.0.0.1')) {
             if (hadInstallation) {
-                console.log('💡 To reconnect, click "Add Access Token" to add your personal access token');
+                Logger.info('💡 To reconnect, click "Add Access Token" to add your personal access token');
             } else {
-                console.log('💡 To reconnect, click "Install GitHub App" and add your access token');
+                Logger.info('💡 To reconnect, click "Install GitHub App" and add your access token');
             }
         }
     }, 100);
@@ -229,13 +229,13 @@ function updateGitHubSignInUI() {
     if (!signInButton) {
         // Only warn in non-test environments (when we're not in JSDOM)
         if (typeof navigator !== 'undefined' && !navigator.userAgent.includes('jsdom')) {
-            console.warn('⚠️ GitHub sign-in button not found in header');
+            Logger.warn('⚠️ GitHub sign-in button not found in header');
         }
         return;
     }
     
     // Debug logging to see authentication state
-    console.log('🔄 Updating GitHub Sign-In UI - Auth state:', {
+    Logger.info('🔄 Updating GitHub Sign-In UI - Auth state:', {
         isAuthenticated: githubAuth.isAuthenticated,
         hasAccessToken: !!githubAuth.accessToken,
         hasUser: !!githubAuth.user,

--- a/src/github-ui.js
+++ b/src/github-ui.js
@@ -100,7 +100,7 @@ function renderMarkdown(text) {
             return html;
             
         } catch (error) {
-            console.error('Error rendering markdown with markdown-it:', error);
+            Logger.error('Error rendering markdown with markdown-it:', error);
             // Fall through to regex-based fallback
         }
     }

--- a/src/github.js
+++ b/src/github.js
@@ -3,7 +3,7 @@
 
 // Initialize GitHub integration when DOM is loaded
 document.addEventListener('DOMContentLoaded', function() {
-    console.log('🔄 Initializing GitHub integration...');
+    Logger.info('🔄 Initializing GitHub integration...');
     
     // Initialize authentication modal listeners
     window.GitHubAuth.initializeAuthModalListeners();
@@ -14,7 +14,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // Load GitHub issues
     window.GitHubAPI.initializeGitHubIssues();
     
-    console.log('✅ GitHub integration initialized');
+    Logger.info('✅ GitHub integration initialized');
 });
 
 // Export functions to global scope for access from kanban.js and backward compatibility

--- a/src/kanban.js
+++ b/src/kanban.js
@@ -2,11 +2,11 @@
 document.addEventListener('DOMContentLoaded', function() {
     // Check essential dependencies
     if (typeof Sortable === 'undefined') {
-        console.error('❌ SortableJS not found. Make sure SortableJS is loaded.');
+        Logger.error('❌ SortableJS not found. Make sure SortableJS is loaded.');
         return;
     }
     
-    console.log('📋 Kanban Board initializing...');
+    Logger.info('📋 Kanban Board initializing...');
 
     // Initialize sortable lists for each column
     const columns = ['info', 'backlog', 'inprogress', 'review', 'done'];
@@ -31,7 +31,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 
                 if (issueNumber && evt.from.id !== evt.to.id) {
                     // This is a GitHub issue that was moved to a different column
-                    console.log(`🏷️ GitHub issue #${issueNumber} moved from ${evt.from.id} to ${newColumnId}`);
+                    Logger.info(`🏷️ GitHub issue #${issueNumber} moved from ${evt.from.id} to ${newColumnId}`);
                     
                     // Update GitHub issue labels if GitHub integration is available
                     if (window.GitHub && window.GitHub.updateGitHubIssueLabels) {
@@ -49,7 +49,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     window.GitHub.updateCardIndicators(draggedElement, newColumnId);
                 }
                 
-                console.log('Task moved from', evt.from.id, 'to', evt.to.id);
+                Logger.info('Task moved from', evt.from.id, 'to', evt.to.id);
             }
         });
     });
@@ -123,7 +123,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (githubIssue) {
                     // Use GitHub issue data to create the task element
                     taskElement = window.GitHub.createGitHubIssueElement(githubIssue, false);
-                    console.log('✅ Created GitHub issue and local task');
+                    Logger.info('✅ Created GitHub issue and local task');
                     
                     // Add to appropriate column
                     document.getElementById(column).appendChild(taskElement);
@@ -144,7 +144,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
                 
             } catch (error) {
-                console.error('Error during GitHub issue creation:', error);
+                Logger.error('Error during GitHub issue creation:', error);
                 alert('An error occurred while creating the GitHub issue. Please try again.');
                 
                 // Restore submit button
@@ -215,7 +215,7 @@ document.addEventListener('DOMContentLoaded', function() {
             } catch (e) {
                 // Only log errors in non-test environments
                 if (typeof jest === 'undefined') {
-                    console.error('Error loading collapse states:', e);
+                    Logger.error('Error loading collapse states:', e);
                 }
                 // Clear invalid data
                 localStorage.removeItem('columnCollapseStates');
@@ -340,7 +340,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const taskElement = e.target.closest('.bg-white.border');
         if (taskElement) {
             // Add edit functionality here
-            console.log('Edit task:', taskElement);
+            Logger.info('Edit task:', taskElement);
         }
     });
 
@@ -416,7 +416,7 @@ document.addEventListener('DOMContentLoaded', function() {
     window.getPriorityColor = getPriorityColor;
     window.getCategoryColor = getCategoryColor;
     
-    console.log('✅ Kanban Board initialized successfully!');
+    Logger.info('✅ Kanban Board initialized successfully!');
 
     // Export certain functions for testing environments
     const testAPI = {

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,59 @@
+class LoggerClass {
+  constructor() {
+    this.levels = { debug: 0, info: 1, warn: 2, error: 3 };
+    this.currentLevel = 'info';
+    this.silent =
+      typeof process !== 'undefined' && process.env.NODE_ENV === 'test';
+  }
+
+  setLevel(level) {
+    if (this.levels[level] !== undefined) {
+      this.currentLevel = level;
+    }
+  }
+
+  log(level, ...args) {
+    if (!this.silent && this.levels[level] >= this.levels[this.currentLevel]) {
+      if (level === 'debug' || level === 'info') {
+        console.log(...args);
+      } else if (level === 'warn') {
+        console.warn(...args);
+      } else if (level === 'error') {
+        console.error(...args);
+      }
+    }
+  }
+
+  setSilent(value) {
+    this.silent = Boolean(value);
+  }
+
+  debug(...args) { this.log('debug', ...args); }
+  info(...args) { this.log('info', ...args); }
+  warn(...args) { this.log('warn', ...args); }
+  error(...args) { this.log('error', ...args); }
+}
+
+// Create a single instance
+const loggerInstance = new LoggerClass();
+
+// Create the global Logger object
+const Logger = {
+  debug: (...args) => loggerInstance.debug(...args),
+  info: (...args) => loggerInstance.info(...args),
+  warn: (...args) => loggerInstance.warn(...args),
+  error: (...args) => loggerInstance.error(...args),
+  setLevel: (level) => loggerInstance.setLevel(level),
+  setSilent: (value) => loggerInstance.setSilent(value)
+};
+
+// Export for both Node.js and browser environments
+(function(moduleObj, globalObj) {
+  if (moduleObj && moduleObj.exports) {
+    moduleObj.exports = Logger;
+  }
+  if (globalObj) {
+    globalObj.Logger = Logger;
+  }
+})(typeof module !== 'undefined' ? module : null,
+   typeof window !== 'undefined' ? window : null);

--- a/src/status-cards.js
+++ b/src/status-cards.js
@@ -59,7 +59,7 @@ document.addEventListener('DOMContentLoaded', function() {
     
     function validateDependencies() {
         if (typeof GitHubUtils === 'undefined') {
-            console.error('❌ GitHubUtils not found. Make sure src/utils.js is loaded.');
+            Logger.error('❌ GitHubUtils not found. Make sure src/utils.js is loaded.');
             return false;
         }
         return true;
@@ -69,7 +69,7 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
 
-    console.log('📊 Status Cards initializing...');
+    Logger.info('📊 Status Cards initializing...');
 
     // ============================================================================
     // UTILITY FUNCTIONS
@@ -124,7 +124,7 @@ document.addEventListener('DOMContentLoaded', function() {
     function safeQuerySelector(selector) {
         const element = document.querySelector(selector);
         if (!element) {
-            console.log(`❌ Element not found: ${selector}`);
+            Logger.info(`❌ Element not found: ${selector}`);
         }
         return element;
     }
@@ -138,10 +138,10 @@ document.addEventListener('DOMContentLoaded', function() {
         
         try {
             const badgeUrl = buildBadgeUrl('workflow', workflowFile);
-            console.log('🚀 Fetching Frontend status from:', badgeUrl);
+            Logger.info('🚀 Fetching Frontend status from:', badgeUrl);
             
             const status = await GitHubUtils.parseBadgeSVG(badgeUrl);
-            console.log('🚀 Frontend status result for frontend.yml:', status);
+            Logger.info('🚀 Frontend status result for frontend.yml:', status);
             
             const workflowData = {
                 status: status,
@@ -152,7 +152,7 @@ document.addEventListener('DOMContentLoaded', function() {
             
             updateWorkflowStatusUI(workflowData, skipTimeUpdate);
         } catch (error) {
-            console.error('Error fetching workflow status:', error);
+            Logger.error('Error fetching workflow status:', error);
             
             const fallbackData = {
                 status: 'unknown',
@@ -172,10 +172,10 @@ document.addEventListener('DOMContentLoaded', function() {
             // Add stronger cache busting for CI status checks
             const timestamp = Date.now();
             const badgeUrl = `${buildBadgeUrl('workflow', workflowFile)}?t=${timestamp}&cacheSeconds=0`;
-            console.log('🔍 Fetching CI status from:', badgeUrl);
+            Logger.info('🔍 Fetching CI status from:', badgeUrl);
             
             const status = await GitHubUtils.parseBadgeSVG(badgeUrl);
-            console.log('🔍 CI status result for test.yml:', status);
+            Logger.info('🔍 CI status result for test.yml:', status);
             
             const ciData = {
                 status: status,
@@ -185,7 +185,7 @@ document.addEventListener('DOMContentLoaded', function() {
             
             updateCIStatusUI(ciData);
         } catch (error) {
-            console.error('Error fetching CI status:', error);
+            Logger.error('Error fetching CI status:', error);
             
             const fallbackData = {
                 status: 'unknown',
@@ -200,7 +200,7 @@ document.addEventListener('DOMContentLoaded', function() {
     async function fetchCoverageStatus() {
         try {
             const badgeUrl = `${buildBadgeUrl('coverage')}?t=${Date.now()}`;
-            console.log('📊 Fetching coverage from:', badgeUrl);
+            Logger.info('📊 Fetching coverage from:', badgeUrl);
             
             const svgText = await fetch(badgeUrl).then(r => r.text());
             const coverage = parseCoverageFromSVG(svgText);
@@ -213,7 +213,7 @@ document.addEventListener('DOMContentLoaded', function() {
             
             updateCoverageStatusUI(coverageData);
         } catch (error) {
-            console.error('Error fetching coverage status:', error);
+            Logger.error('Error fetching coverage status:', error);
             
             const fallbackData = {
                 coverage: 'unknown',
@@ -248,13 +248,13 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function updateCIStatusUI(ciData) {
-        console.log('🎯 Updating CI status UI with:', ciData);
+        Logger.info('🎯 Updating CI status UI with:', ciData);
         const statusElement = safeQuerySelector(CONFIG.SELECTORS.CI_STATUS);
         
         if (!statusElement) return;
         
         const config = STATUS_CONFIGS.CI[ciData.status] || STATUS_CONFIGS.CI.unknown;
-        console.log('🎯 Using config for CI status:', config);
+        Logger.info('🎯 Using config for CI status:', config);
         
         statusElement.innerHTML = createStatusHTML(config, ciData.status);
         makeElementClickable(statusElement, ciData.htmlUrl);
@@ -292,13 +292,13 @@ document.addEventListener('DOMContentLoaded', function() {
     // ============================================================================
     
     function parseCoverageFromSVG(svgText) {
-        console.log('📊 Parsing coverage SVG...');
+        Logger.info('📊 Parsing coverage SVG...');
         
         // Method 1: Look for percentage patterns in SVG text content
         const percentMatch = svgText.match(/(\d+(?:\.\d+)?)%/);
         if (percentMatch) {
             const percent = parseFloat(percentMatch[1]);
-            console.log(`📊 Found coverage percentage: ${percent}%`);
+            Logger.info(`📊 Found coverage percentage: ${percent}%`);
             return percent;
         }
         
@@ -309,7 +309,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const percentInText = textContent.match(/(\d+(?:\.\d+)?)%/);
             if (percentInText) {
                 const percent = parseFloat(percentInText[1]);
-                console.log(`📊 Found coverage in text: ${percent}%`);
+                Logger.info(`📊 Found coverage in text: ${percent}%`);
                 return percent;
             }
         }
@@ -317,7 +317,7 @@ document.addEventListener('DOMContentLoaded', function() {
         // Method 3: Look for common status words
         const lowerText = svgText.toLowerCase();
         if (lowerText.includes('unknown') || lowerText.includes('pending') || lowerText.includes('inaccessible')) {
-            console.log('📊 Coverage status: unknown/pending/inaccessible');
+            Logger.info('📊 Coverage status: unknown/pending/inaccessible');
             return 'unknown';
         }
         
@@ -327,12 +327,12 @@ document.addEventListener('DOMContentLoaded', function() {
             const number = parseFloat(numberMatch[1]);
             // Assume it's a percentage if it's reasonable
             if (number >= 0 && number <= 100) {
-                console.log(`📊 Found potential coverage number: ${number}%`);
+                Logger.info(`📊 Found potential coverage number: ${number}%`);
                 return number;
             }
         }
         
-        console.log('📊 Could not parse coverage from SVG');
+        Logger.info('📊 Could not parse coverage from SVG');
         return 'unknown';
     }
 
@@ -377,19 +377,19 @@ document.addEventListener('DOMContentLoaded', function() {
                 // Also refresh our status detection and timestamp
                 refreshAllStatuses();
                 
-                console.log('Badge refreshed manually');
+                Logger.info('Badge refreshed manually');
             });
         }
         
         if (badgeImg) {
             badgeImg.addEventListener('load', function() {
-                console.log('Badge loaded successfully');
-                console.log('Badge dimensions:', this.naturalWidth, 'x', this.naturalHeight);
-                console.log('Badge src:', this.src);
+                Logger.info('Badge loaded successfully');
+                Logger.info('Badge dimensions:', this.naturalWidth, 'x', this.naturalHeight);
+                Logger.info('Badge src:', this.src);
             });
             
             badgeImg.addEventListener('error', function() {
-                console.error('Badge failed to load');
+                Logger.error('Badge failed to load');
             });
         }
     }
@@ -422,7 +422,7 @@ document.addEventListener('DOMContentLoaded', function() {
         setInterval(refreshAllStatuses, CONFIG.INTERVALS.REFRESH_ALL);
         setInterval(updateTimestamp, CONFIG.INTERVALS.UPDATE_TIMESTAMP);
 
-        console.log('Status Cards initialized successfully!');
+        Logger.info('Status Cards initialized successfully!');
     }
 
     // ============================================================================

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,31 +4,31 @@ function parseStatusFromSVG(svgText) {
     // Convert to lowercase for easier matching
     const lowerText = svgText.toLowerCase();
     
-    console.log('Searching for status words in SVG...');
+    Logger.info('Searching for status words in SVG...');
     
     // Look for common status words
     if (lowerText.includes('passing') || lowerText.includes('success')) {
-        console.log('✅ Found "passing" or "success" in SVG');
+        Logger.info('✅ Found "passing" or "success" in SVG');
         return 'success';
     }
     
     if (lowerText.includes('failing') || lowerText.includes('failure') || lowerText.includes('failed')) {
-        console.log('❌ Found "failing" or "failure" in SVG');
+        Logger.info('❌ Found "failing" or "failure" in SVG');
         return 'failure';
     }
     
     if (lowerText.includes('pending') || lowerText.includes('running') || lowerText.includes('in progress')) {
-        console.log('🔄 Found "pending" or "running" in SVG');
+        Logger.info('🔄 Found "pending" or "running" in SVG');
         return 'in_progress';
     }
     
     if (lowerText.includes('no status') || lowerText.includes('unknown')) {
-        console.log('❔ Found "no status" or "unknown" in SVG');
+        Logger.info('❔ Found "no status" or "unknown" in SVG');
         return 'unknown';
     }
     
     // If we can't find specific status words, log what we found
-    console.log('⚠️ No recognized status words found. SVG might contain:', 
+    Logger.info('⚠️ No recognized status words found. SVG might contain:', 
                svgText.match(/>([^<]+)</g)?.map(match => match.slice(1, -1)).filter(text => text.trim()));
     
     return 'unknown';
@@ -48,7 +48,7 @@ function parseShieldsStatus(statusValue) {
     if (!statusValue) return 'unknown';
     
     const status = statusValue.toLowerCase();
-    console.log('Status value from shields.io:', status);
+    Logger.info('Status value from shields.io:', status);
     
     // Map shields.io status values to our status system
     if (status.includes('passing') || status.includes('success')) {
@@ -78,14 +78,14 @@ async function parseBadgeSVG(badgeUrl) {
         }
         
         const svgText = await response.text();
-        console.log('Badge SVG content:', svgText);
+        Logger.info('Badge SVG content:', svgText);
         
         // Parse the SVG text for status words
         const status = parseStatusFromSVG(svgText);
         return status;
         
     } catch (error) {
-        console.error('Error fetching SVG badge:', error);
+        Logger.error('Error fetching SVG badge:', error);
         return 'unknown';
     }
 }

--- a/tests/github-api.test.js
+++ b/tests/github-api.test.js
@@ -22,6 +22,7 @@ const mockLocalStorage = {
 const mockFetch = jest.fn();
 const mockAlert = jest.fn();
 const mockConfirm = jest.fn();
+const Logger = require('../src/logger.js');
 
 // Setup DOM and global mocks
 beforeEach(() => {
@@ -39,6 +40,7 @@ beforeEach(() => {
     global.alert = mockAlert;
     global.confirm = mockConfirm;
     global.navigator = { userAgent: 'test' };
+    global.Logger = Logger;
     
     // Override window.localStorage to ensure the mock is used
     Object.defineProperty(window, 'localStorage', {
@@ -65,6 +67,7 @@ beforeEach(() => {
             sanitize: jest.fn((html) => html)
         }
     };
+    global.window.Logger = Logger;
 
     // Mock window functions needed by GitHub API
     global.window.getPriorityColor = jest.fn((priority) => 'bg-red-100 text-red-800');
@@ -662,10 +665,14 @@ describe('GitHub API', () => {
             // Temporarily hide jest to trigger non-test environment logging
             const originalJest = global.jest;
             delete global.jest;
+            const originalSilent = Logger.silent;
+            Logger.setSilent(false);
 
             // Mock console.error to capture the call
             const originalConsoleError = console.error;
+            const originalConsoleLog = console.log;
             console.error = jest.fn();
+            console.log = jest.fn();
 
             mockFetch.mockRejectedValueOnce(new Error('Network error'));
 
@@ -679,6 +686,8 @@ describe('GitHub API', () => {
             // Restore
             global.jest = originalJest;
             console.error = originalConsoleError;
+            console.log = originalConsoleLog;
+            Logger.setSilent(originalSilent);
         });
     });
 

--- a/tests/github-auth.test.js
+++ b/tests/github-auth.test.js
@@ -22,6 +22,7 @@ const mockLocalStorage = {
 const mockFetch = jest.fn();
 const mockAlert = jest.fn();
 const mockConfirm = jest.fn();
+const Logger = require('../src/logger.js');
 
 // Setup DOM and global mocks
 beforeEach(() => {
@@ -71,7 +72,7 @@ beforeEach(() => {
         destroy: jest.fn()
     }));
     global.window = {
-        location: { 
+        location: {
             origin: 'https://dashban.com',
             pathname: '/',
             href: 'https://dashban.com/',
@@ -79,6 +80,8 @@ beforeEach(() => {
         },
         history: { replaceState: jest.fn() }
     };
+    global.window.Logger = Logger;
+    global.Logger = Logger;
     global.URL = jest.fn().mockImplementation((url) => ({
         searchParams: {
             set: jest.fn()
@@ -94,6 +97,10 @@ beforeEach(() => {
     mockAlert.mockReset();
     mockConfirm.mockReset();
     mockLocalStorage.clear();
+
+    Logger.info = jest.fn();
+    Logger.error = jest.fn();
+    Logger.warn = jest.fn();
 
     // Set up default mock responses for GitHub API calls
     mockFetch.mockImplementation((url) => {
@@ -543,9 +550,9 @@ describe('GitHub Authentication', () => {
                 configurable: true
             });
             
-            // Mock console.warn
-            const originalConsoleWarn = console.warn;
-            console.warn = jest.fn();
+            // Mock logger warn
+            const originalWarn = Logger.warn;
+            Logger.warn = jest.fn();
 
             // Remove all possible sign-in buttons from header
             const header = document.querySelector('header');
@@ -554,10 +561,10 @@ describe('GitHub Authentication', () => {
 
             window.GitHubAuth.updateGitHubSignInUI();
 
-            expect(console.warn).toHaveBeenCalledWith('⚠️ GitHub sign-in button not found in header');
+            expect(Logger.warn).toHaveBeenCalledWith('⚠️ GitHub sign-in button not found in header');
             
             // Restore
-            console.warn = originalConsoleWarn;
+            Logger.warn = originalWarn;
             Object.defineProperty(navigator, 'userAgent', {
                 value: originalUserAgent,
                 configurable: true
@@ -581,7 +588,7 @@ describe('GitHub Authentication', () => {
         });
 
         test('handleInstallationCallback should handle real error during installation', async () => {
-            const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+            const consoleSpy = jest.spyOn(Logger, 'error').mockImplementation(() => {});
             global.alert = jest.fn();
 
             // Create an actual error scenario by calling the function with invalid parameters that will cause an error
@@ -601,7 +608,7 @@ describe('GitHub Authentication', () => {
         });
 
         test('validateAndSetInstallation should handle real error', async () => {
-            const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+            const consoleSpy = jest.spyOn(Logger, 'error').mockImplementation(() => {});
             
             // Force an error by passing an object that will cause issues
             try {
@@ -1200,7 +1207,7 @@ describe('GitHub Authentication', () => {
 
     describe('Error Handling and Edge Cases', () => {
         test('validateAndSetInstallation should handle error gracefully', async () => {
-            const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+            const consoleSpy = jest.spyOn(Logger, 'error').mockImplementation(() => {});
             
             // Mock an error in the validation
             const result = await window.GitHubAuth.validateAndSetInstallation('invalid-id');
@@ -1212,14 +1219,14 @@ describe('GitHub Authentication', () => {
         });
 
         test('handleInstallationCallback should handle error during installation', async () => {
-            const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+            const consoleSpy = jest.spyOn(Logger, 'error').mockImplementation(() => {});
             global.alert = jest.fn();
 
             // Force an error by passing invalid data
             try {
                 throw new Error('Installation failed');
             } catch (error) {
-                console.error('❌ Installation callback error:', error);
+                Logger.error('❌ Installation callback error:', error);
                 alert('Installation failed. Please try again.');
             }
 
@@ -1272,16 +1279,16 @@ describe('GitHub Authentication', () => {
             // Mock localStorage to simulate having installation
             localStorage.setItem('github_installation_id', '123456');
 
-            // Mock console.log to capture the timeout callback
-            const originalConsoleLog = console.log;
-            console.log = jest.fn();
+            // Mock logger info to capture the timeout callback
+            const originalInfo = Logger.info;
+            Logger.info = jest.fn();
 
             window.GitHubAuth.signOutGitHub();
 
             // Wait for setTimeout callback
             setTimeout(() => {
-                expect(console.log).toHaveBeenCalledWith('💡 To reconnect, click "Add Access Token" to add your personal access token');
-                console.log = originalConsoleLog;
+                expect(Logger.info).toHaveBeenCalledWith('💡 To reconnect, click "Add Access Token" to add your personal access token');
+                Logger.info = originalInfo;
                 done();
             }, 150);
         });
@@ -1298,16 +1305,16 @@ describe('GitHub Authentication', () => {
             // Clear localStorage to simulate no installation
             localStorage.removeItem('github_installation_id');
 
-            // Mock console.log to capture the timeout callback
-            const originalConsoleLog = console.log;
-            console.log = jest.fn();
+            // Mock logger info to capture the timeout callback
+            const originalInfo = Logger.info;
+            Logger.info = jest.fn();
 
             window.GitHubAuth.signOutGitHub();
 
             // Wait for setTimeout callback
             setTimeout(() => {
-                expect(console.log).toHaveBeenCalledWith('💡 To reconnect, click "Install GitHub App" and add your access token');
-                console.log = originalConsoleLog;
+                expect(Logger.info).toHaveBeenCalledWith('💡 To reconnect, click "Install GitHub App" and add your access token');
+                Logger.info = originalInfo;
                 done();
             }, 150);
         });

--- a/tests/github-ui.test.js
+++ b/tests/github-ui.test.js
@@ -2,6 +2,8 @@
  * GitHub UI Tests
  */
 
+const Logger = require('../src/logger.js');
+
 // Setup DOM and global mocks
 beforeEach(() => {
     // Reset DOM
@@ -11,6 +13,11 @@ beforeEach(() => {
         <div id="review"></div>
         <div id="done"></div>
     `;
+
+    Logger.info = jest.fn();
+    Logger.error = jest.fn();
+    Logger.warn = jest.fn();
+    global.Logger = Logger;
 
     // Mock SortableJS
     global.Sortable = jest.fn().mockImplementation(() => ({
@@ -32,6 +39,7 @@ beforeEach(() => {
         getCategoryColor: jest.fn((category) => 'bg-green-100 text-green-800'),
         GitHubUI: {}
     };
+    global.window.Logger = Logger;
 
     // Load the module
     require('../src/github-ui.js');

--- a/tests/github.test.js
+++ b/tests/github.test.js
@@ -3,6 +3,8 @@
  * Tests the coordination between auth, API, and UI modules
  */
 
+const Logger = require('../src/logger.js');
+
 // Setup DOM and global mocks
 beforeEach(() => {
     // Reset DOM
@@ -21,6 +23,11 @@ beforeEach(() => {
         <div id="done"></div>
     `;
 
+    Logger.info = jest.fn();
+    Logger.error = jest.fn();
+    Logger.warn = jest.fn();
+    global.Logger = Logger;
+
     // Mock global objects
     global.window = {
         location: { 
@@ -36,6 +43,7 @@ beforeEach(() => {
             sanitize: jest.fn((html) => html)
         }
     };
+    global.window.Logger = Logger;
 
     // Load the kanban module first to set up window functions
     delete require.cache[require.resolve('../src/kanban.js')];

--- a/tests/kanban.test.js
+++ b/tests/kanban.test.js
@@ -5,6 +5,8 @@
  * GitHub integration tests are in github.test.js
  */
 
+const Logger = require('../src/logger.js');
+
 // Set up DOM and environment for testing
 function setupDOM() {
   document.body.innerHTML = `
@@ -189,12 +191,18 @@ beforeAll(() => {
   global.window.updateColumnCounts = jest.fn();
   global.window.getPriorityColor = jest.fn().mockReturnValue('bg-gray-100 text-gray-800');
   global.window.getCategoryColor = jest.fn().mockReturnValue('bg-gray-100 text-gray-800');
+  global.window.Logger = Logger;
 });
 
 beforeEach(() => {
   setupDOM();
   localStorageMock.clear();
   jest.clearAllMocks();
+
+  Logger.info = jest.fn();
+  Logger.error = jest.fn();
+  Logger.warn = jest.fn();
+  global.Logger = Logger;
   
   // Ensure localStorage mock is properly set for this test
   global.localStorage = localStorageMock;
@@ -636,14 +644,14 @@ describe('Kanban Board Core Functionality', () => {
       const backlog = document.getElementById('backlog');
       backlog.appendChild(taskElement);
       
-      console.log = jest.fn();
+      Logger.info = jest.fn();
       
       // Simulate double-click
       const event = new Event('dblclick', { bubbles: true });
       taskElement.dispatchEvent(event);
       
       // Should log edit event (placeholder functionality)
-      expect(console.log).toHaveBeenCalledWith('Edit task:', taskElement);
+      expect(Logger.info).toHaveBeenCalledWith('Edit task:', taskElement);
     });
   });
 
@@ -735,7 +743,7 @@ describe('Kanban Board Core Functionality', () => {
       // Wait for async error handling
       await new Promise(resolve => setTimeout(resolve, 0));
       
-      expect(console.error).toHaveBeenCalled();
+      expect(Logger.error).toHaveBeenCalled();
       expect(global.alert).toHaveBeenCalledWith(
         'An error occurred while creating the GitHub issue. Please try again.'
       );

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,12 +1,14 @@
 // Tests for GitHub Actions utility functions
 const utils = require('../src/utils.js');
+const Logger = require('../src/logger.js');
 
 describe('GitHub Actions Status Functions', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         global.fetch = jest.fn();
-        console.log = jest.fn();
-        console.error = jest.fn();
+        Logger.info = jest.fn();
+        Logger.error = jest.fn();
+        global.Logger = Logger;
     });
 
     describe('parseStatusFromSVG', () => {
@@ -14,7 +16,7 @@ describe('GitHub Actions Status Functions', () => {
             const svgWithPassing = '<svg><text>build passing</text></svg>';
             const result = utils.parseStatusFromSVG(svgWithPassing);
             expect(result).toBe('success');
-            expect(console.log).toHaveBeenCalledWith('✅ Found "passing" or "success" in SVG');
+            expect(Logger.info).toHaveBeenCalledWith('✅ Found "passing" or "success" in SVG');
         });
 
         test('should detect success status from SVG containing "success"', () => {
@@ -27,7 +29,7 @@ describe('GitHub Actions Status Functions', () => {
             const svgWithFailing = '<svg><text>build failing</text></svg>';
             const result = utils.parseStatusFromSVG(svgWithFailing);
             expect(result).toBe('failure');
-            expect(console.log).toHaveBeenCalledWith('❌ Found "failing" or "failure" in SVG');
+            expect(Logger.info).toHaveBeenCalledWith('❌ Found "failing" or "failure" in SVG');
         });
 
         test('should detect failure status from SVG containing "failure"', () => {
@@ -46,7 +48,7 @@ describe('GitHub Actions Status Functions', () => {
             const svgWithRunning = '<svg><text>build running</text></svg>';
             const result = utils.parseStatusFromSVG(svgWithRunning);
             expect(result).toBe('in_progress');
-            expect(console.log).toHaveBeenCalledWith('🔄 Found "pending" or "running" in SVG');
+            expect(Logger.info).toHaveBeenCalledWith('🔄 Found "pending" or "running" in SVG');
         });
 
         test('should detect in_progress status from SVG containing "pending"', () => {
@@ -59,14 +61,14 @@ describe('GitHub Actions Status Functions', () => {
             const svgWithInProgress = '<svg><text>build in progress</text></svg>';
             const result = utils.parseStatusFromSVG(svgWithInProgress);
             expect(result).toBe('in_progress');
-            expect(console.log).toHaveBeenCalledWith('🔄 Found "pending" or "running" in SVG');
+            expect(Logger.info).toHaveBeenCalledWith('🔄 Found "pending" or "running" in SVG');
         });
 
         test('should detect unknown status from SVG containing "no status"', () => {
             const svgWithNoStatus = '<svg><text>no status</text></svg>';
             const result = utils.parseStatusFromSVG(svgWithNoStatus);
             expect(result).toBe('unknown');
-            expect(console.log).toHaveBeenCalledWith('❔ Found "no status" or "unknown" in SVG');
+            expect(Logger.info).toHaveBeenCalledWith('❔ Found "no status" or "unknown" in SVG');
         });
 
         test('should return unknown for SVG without recognizable status', () => {
@@ -92,7 +94,7 @@ describe('GitHub Actions Status Functions', () => {
             const result = utils.parseStatusFromSVG(svgWithText);
             expect(result).toBe('unknown');
             // This should trigger the regex matching logic and logging
-            expect(console.log).toHaveBeenCalledWith(
+            expect(Logger.info).toHaveBeenCalledWith(
                 '⚠️ No recognized status words found. SVG might contain:',
                 expect.any(Array)
             );
@@ -248,8 +250,9 @@ describe('parseBadgeSVG function', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         global.fetch = jest.fn();
-        console.log = jest.fn();
-        console.error = jest.fn();
+        Logger.info = jest.fn();
+        Logger.error = jest.fn();
+        global.Logger = Logger;
     });
 
     test('should successfully parse SVG from a valid URL', async () => {
@@ -262,7 +265,7 @@ describe('parseBadgeSVG function', () => {
         const result = await utils.parseBadgeSVG('https://example.com/badge.svg');
         
         expect(result).toBe('success');
-        expect(console.log).toHaveBeenCalledWith('Badge SVG content:', mockSVG);
+        expect(Logger.info).toHaveBeenCalledWith('Badge SVG content:', mockSVG);
     });
 
     test('should handle HTTP errors gracefully', async () => {
@@ -274,7 +277,7 @@ describe('parseBadgeSVG function', () => {
         const result = await utils.parseBadgeSVG('https://example.com/nonexistent.svg');
         
         expect(result).toBe('unknown');
-        expect(console.error).toHaveBeenCalledWith(
+        expect(Logger.error).toHaveBeenCalledWith(
             'Error fetching SVG badge:',
             expect.any(Error)
         );
@@ -286,7 +289,7 @@ describe('parseBadgeSVG function', () => {
         const result = await utils.parseBadgeSVG('https://example.com/badge.svg');
         
         expect(result).toBe('unknown');
-        expect(console.error).toHaveBeenCalledWith(
+        expect(Logger.error).toHaveBeenCalledWith(
             'Error fetching SVG badge:',
             expect.any(Error)
         );


### PR DESCRIPTION
## Summary
- add a `silent` option in `Logger` that defaults to true when `NODE_ENV=test`
- allow tests to override silence with `Logger.setSilent(false)`
- update unit test expecting console output
- silence non-essential console output when testing error logging behavior
- merge latest changes from main to ensure updated logger class structure

## Testing
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_684b5339b9b883208931e27d92c5eafe