### PR TITLE
Remove unused GitHub auth callbacks

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -27,9 +27,7 @@ window.GitHub = {
     // Authentication functions (from GitHubAuth)
     initializeGitHubAuth: window.GitHubAuth.initializeGitHubAuth,
     signInWithGitHub: window.GitHubAuth.signInWithGitHub,
-    handleInstallationCallback: window.GitHubAuth.handleInstallationCallback,
     validateAndSetToken: window.GitHubAuth.validateAndSetToken,
-    validateAndSetInstallation: window.GitHubAuth.validateAndSetInstallation,
     signOutGitHub: window.GitHubAuth.signOutGitHub,
     updateGitHubSignInUI: window.GitHubAuth.updateGitHubSignInUI,
     updateGitHubOptionUI: window.GitHubAuth.updateGitHubOptionUI,


### PR DESCRIPTION
## Summary
- delete exports for handleInstallationCallback and validateAndSetInstallation from `src/github.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f6353577c8320879cc9ed9c1cc636