### PR TITLE
Remove keyboard shortcuts from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,6 @@ npm install && npm test
 
 Open `index.html` in your browser to start using Dashban.
 
-### ⌨️ Keyboard Shortcuts
-- `Ctrl/Cmd + N`: Add new task
-- `Escape`: Close modal
-
 ## 🚀 Frontend Deployment
 
 This project includes a GitHub Actions workflow for automatic deployment to GitHub Pages. To enable deployment:


### PR DESCRIPTION
The `README.md` file was modified to remove the keyboard shortcuts section.

Specifically:
*   The entire "⌨️ Keyboard Shortcuts" heading and its associated bullet points, which detailed `Ctrl/Cmd   N` for adding new tasks and `Escape` for closing modals, were removed from `README.md`.

This change streamlines the document, allowing the "Quick Start" section to flow directly into the "Frontend Deployment" section without interruption from keyboard shortcut documentation.