### PR TITLE
Hide "Add Issue" text on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,11 +181,11 @@
                 <div class="flex items-center space-x-4">
                     <button id="add-task-btn" class="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-lg font-medium transition-colors duration-200 flex items-center space-x-2">
                         <i class="fas fa-plus"></i>
-                        <span>Add Issue</span>
+                        <span class="hidden sm:inline">Add Issue</span>
                     </button>
                     <a href="https://github.com/super3/dashban" target="_blank" class="flex items-center space-x-2 bg-gray-900 hover:bg-gray-800 text-white px-4 py-2 rounded-lg font-medium transition-colors duration-200">
                         <i class="fab fa-github"></i>
-                        <span>Connect to GitHub</span>
+                        <span class="hidden sm:inline">Connect to GitHub</span>
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
The `<span>` element containing "Add Issue" within the "Add Issue" button in `index.html` was updated with `class="hidden sm:inline"`. This change hides the text on smaller screens, displaying only the `fas fa-plus` icon, and makes the text visible from the `sm` breakpoint (640px) upwards.

To maintain visual consistency and prevent vertical resizing, the same `hidden sm:inline` class was applied to the `<span>` element for the "Connect to GitHub" button.

These modifications ensure:
*   On mobile devices, both buttons display only their icons.
*   On small screens and larger, both buttons show their full text.
*   Both buttons maintain consistent height and padding across all screen sizes, preventing vertical layout shifts in the navbar.