### PR TITLE
Fix coverage status card (shields.io CORS redirect)

### DIFF
--- a/src/status-cards.js
+++ b/src/status-cards.js
@@ -118,7 +118,11 @@ document.addEventListener('DOMContentLoaded', function() {
         if (type === 'workflow') {
             return `https://img.shields.io/github/actions/workflow/status/${OWNER}/${REPO}/${workflowFile}`;
         } else if (type === 'coverage') {
-            return `https://img.shields.io/coveralls/github/${OWNER}/${REPO}/main.svg`;
+            // shields.io deprecated the /coveralls/ path — it now 301-redirects
+            // to a URL that fails CORS, which breaks reading the SVG body from
+            // the browser. The current /coverallsCoverage/ endpoint serves the
+            // badge directly with CORS headers.
+            return `https://img.shields.io/coverallsCoverage/github/${OWNER}/${REPO}?branch=main`;
         }
         throw new Error(`Unknown badge type: ${type}`);
     }
@@ -214,7 +218,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
     async function fetchCoverageStatus() {
         try {
-            const badgeUrl = `${buildBadgeUrl('coverage')}?t=${Date.now()}`;
+            // The coverage badge URL already carries a query (?branch=main), so
+            // join the cache-buster with & rather than ?.
+            const badgeUrl = `${buildBadgeUrl('coverage')}&t=${Date.now()}`;
             
             const svgText = await fetch(badgeUrl).then(r => r.text());
             const coverage = parseCoverageFromSVG(svgText);

--- a/tests/status-cards.test.js
+++ b/tests/status-cards.test.js
@@ -303,7 +303,7 @@ describe('Status Cards Functions', () => {
 
       test('should build coverage badge URL correctly', () => {
         const result = statusAPI.buildBadgeUrl('coverage');
-        expect(result).toBe('https://img.shields.io/coveralls/github/super3/dashban/main.svg');
+        expect(result).toBe('https://img.shields.io/coverallsCoverage/github/super3/dashban?branch=main');
       });
 
       test('should throw error for unknown badge type', () => {
@@ -960,7 +960,7 @@ describe('Status Cards Functions', () => {
       
       // With no GitHubAuth setup, it uses default config
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining('https://img.shields.io/coveralls/github/super3/dashban/main.svg?t=')
+        expect.stringContaining('https://img.shields.io/coverallsCoverage/github/super3/dashban?branch=main&t=')
       );
     });
 


### PR DESCRIPTION
## Problem

On dashban.com the browser console shows:

```
Access to fetch at 'https://img.shields.io/coverallsCoverage/github/super3/dashban.svg?...&branch=main'
(redirected from 'https://img.shields.io/coveralls/github/super3/dashban/main.svg?...')
blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present
status-cards.js: Error fetching coverage status: TypeError: Failed to fetch
```

shields.io **deprecated** the `/coveralls/` badge path. It now `301`-redirects to a `/coverallsCoverage/...svg` URL whose response carries no `Access-Control-Allow-Origin` header (it returns `408` for that variant), so the browser blocks `fetchCoverageStatus` from reading the SVG body cross-origin. The coverage card silently falls back to "unknown".

This is pre-existing and unrelated to the recent Clerk auth work (#72) — it only surfaced when looking at the console.

## Fix

Point `buildBadgeUrl('coverage')` at the current non-redirecting endpoint:

`https://img.shields.io/coverallsCoverage/github/super3/dashban?branch=main`

Verified: returns `200` with `access-control-allow-origin: *` and a parseable SVG body. The cache-buster is now joined with `&` since this URL already carries `?branch=main`.

## Testing

- `npm test` — 959 passing (updated the two `status-cards` assertions for the new URL).
- `npm run test:coverage` — **100%** across all files (`status-cards.js` included).
- `npm run lint` — 0 errors (7 pre-existing warnings unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VQjXJyM3EZPd4joy3EwaB

---
_Generated by [Claude Code](https://claude.ai/code/session_019VQjXJyM3EZPd4joy3EwaB)_