### PR TITLE
Add "Manage GitHub access" link to the account dropdown

### DIFF
--- a/src/github-auth.js
+++ b/src/github-auth.js
@@ -184,6 +184,12 @@ function toggleUserDropdown() {
     const dropdown = document.createElement('div');
     dropdown.className = 'user-dropdown absolute right-0 top-full mt-2 w-48 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-50';
     dropdown.innerHTML = `
+        <a href="https://github.com/settings/installations" target="_blank" rel="noopener noreferrer"
+           class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center space-x-2">
+            <i class="fas fa-key text-xs"></i>
+            <span>Manage GitHub access</span>
+        </a>
+        <div class="border-t border-gray-100 my-1"></div>
         <button class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center space-x-2">
             <i class="fas fa-sign-out-alt text-xs"></i>
             <span>Sign out</span>

--- a/tests/github-auth.test.js
+++ b/tests/github-auth.test.js
@@ -305,6 +305,15 @@ describe('GitHub Authentication (Clerk-only)', () => {
             expect(container.querySelector('.user-dropdown')).toBeNull();
         });
 
+        test('includes a link to manage the GitHub App repository access', () => {
+            window.GitHubAuth.toggleUserDropdown();
+
+            const link = container.querySelector('.user-dropdown a[href="https://github.com/settings/installations"]');
+            expect(link).not.toBeNull();
+            expect(link.getAttribute('target')).toBe('_blank');
+            expect(link.textContent).toContain('Manage GitHub access');
+        });
+
         test('Sign out triggers Clerk sign-out', () => {
             window.ClerkAuth = { signOut: jest.fn() };
             window.GitHubAuth.toggleUserDropdown();


### PR DESCRIPTION
## What

Adds a **Manage GitHub access** item to the signed-in user (account) dropdown in the header, next to "Sign out". It opens GitHub's installed-apps settings (`https://github.com/settings/installations`) in a new tab.

## Why

When you add a repo to dashban, the GitHub App still needs to be granted access to that repo before it can read/write its issues. This puts a one-click path to manage that access in the account menu (add or remove repo permissions as needed).

_(Updated from the first version of this PR, which placed the link in the repository dropdown — moved to the account dropdown per review.)_

## Note on the destination

The link lands on your **Installed GitHub Apps** list, where you click the dashban app to manage its repository access. If you'd like it to deep-link straight to the dashban app's repo-selection page instead, tell me the app's slug (`github.com/apps/<slug>`) and I'll point it at `https://github.com/apps/<slug>/installations/select_target`.

## Testing

- `npm test` — 966 passing (added an assertion for the link in the user-dropdown test).
- `npm run test:coverage` — 100% across all files.
- `npm run lint` — 0 errors (7 pre-existing warnings unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VQjXJyM3EZPd4joy3EwaB